### PR TITLE
Ensure default logo path appears

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -51,7 +51,7 @@ if ($table_exists) {
         // Inserir configurações iniciais
         $sql_insert = "INSERT INTO configuracoes (chave, valor, descricao, tipo) VALUES
             ('nome_empresa', 'Zaion GC', 'Nome da empresa exibido no sistema e comprovantes', 'texto'),
-            ('logo_url', '', 'URL da logomarca da empresa', 'imagem'),
+            ('logo_url', 'assets/images/logo.png', 'URL da logomarca da empresa', 'imagem'),
             ('telefone_empresa', '', 'Telefone de contato da empresa', 'texto'),
             ('email_empresa', '', 'Email de contato da empresa', 'texto'),
             ('endereco_empresa', '', 'Endereço da empresa', 'texto'),
@@ -63,7 +63,7 @@ if ($table_exists) {
         
         // Carregar as configurações padrão
         $config['nome_empresa'] = 'Zaion GC';
-        $config['logo_url'] = '';
+        $config['logo_url'] = 'assets/images/logo.png';
         $config['telefone_empresa'] = '';
         $config['email_empresa'] = '';
         $config['endereco_empresa'] = '';
@@ -80,6 +80,12 @@ if (!isset($config['nome_empresa'])) {
 if (!isset($config['mensagem_comprovante'])) {
     $config['mensagem_comprovante'] = "Agradecemos pela preferência!\nPara mais informações, entre em contato conosco.";
 }
+if (empty($config['logo_url'])) {
+    $config['logo_url'] = 'assets/images/logo.png';
+}
+
+// Disponibilizar configurações na sessão para uso global
+$_SESSION['config'] = $config;
 
 // Função para obter o caminho base da aplicação
 function getBasePath() {

--- a/includes/header.php
+++ b/includes/header.php
@@ -48,7 +48,8 @@ $is_extras = ($is_funcionarios && strpos($current_uri, '/extras') !== false);
 
 // Carrega configurações da sessão ou usa valores padrão.
 $empresa_nome = $_SESSION['config']['nome_empresa'] ?? 'Domaria Cafe';
-$logo_url = $_SESSION['config']['logo_url'] ?? 'assets/images/logo.png';
+$logo_session = $_SESSION['config']['logo_url'] ?? '';
+$logo_url = !empty($logo_session) ? $logo_session : 'assets/images/logo.png';
 $versao_sistema = $_SESSION['config']['versao_sistema'] ?? '1.4';
 $cor_primaria = $_SESSION['config']['cor_primaria'] ?? '#343a40';
 $cor_secundaria = $_SESSION['config']['cor_secundaria'] ?? '#6c757d';


### PR DESCRIPTION
## Summary
- set default `logo_url` path in the database bootstrap and when configs are empty
- store the configuration array in the session for global access
- fall back to default logo when session value is empty

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684754494b2083319654642aa922630d